### PR TITLE
Address state null fix

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/pmclain_stripe.js
+++ b/view/frontend/web/js/view/payment/method-renderer/pmclain_stripe.js
@@ -332,6 +332,10 @@ define(
           stripeData.address_state = billingAddress.regionCode;
         }
 
+        if (stripeData.address_state == null){
+          stripeData.address_state = '';
+        }
+
         return stripeData;
       }
     });

--- a/view/frontend/web/js/view/payment/method-renderer/pmclain_stripe.js
+++ b/view/frontend/web/js/view/payment/method-renderer/pmclain_stripe.js
@@ -308,6 +308,10 @@ define(
               ownerData.owner.address.state = billingAddress.regionCode;
           }
 
+          if (stripeData.address_state == null){
+            stripeData.address_state = '';
+          }
+
           return ownerData;
       },
 


### PR DESCRIPTION
When creating a payment with the state/region missing there is an error which prevents completion of checkout due to the address_state being set as null:

```
JQMIGRATE: Logging is active
(index):1 Uncaught (in promise) Error: Invalid value for token creation parameter: address_state should be a string. You specified: null.
at new t ((index):1)
at e.Jn._handleMessage ((index):1)
at e._handleMessage ((index):1)
at (index):1
t @ (index):1
Jn._handleMessage @ (index):1
(anonymous) @ (index):1
(anonymous) @ (index):1
Promise.then (async)
createToken @ pmclain_stripe.js:98
placeOrder @ pmclain_stripe.js:69
(anonymous) @ knockout.js:3863
dispatch @ jquery.js:5226
elemData.handle @ jquery.js:4878
trigger @ jquery.js:5130
jQuery.event.trigger @ jquery-migrate.js:493
(anonymous) @ jquery.js:5860
each @ jquery.js:370
each @ jquery.js:137
trigger @ jquery.js:5859
jQuery.fn.(anonymous function) @ jquery.js:8983
clickNativePlaceOrder @ payment.js:244
(anonymous) @ payment.js:235
fire @ jquery.js:3232
fireWith @ jquery.js:3362
done @ jquery.js:9840
callback @ jquery.js:10311
XMLHttpRequest.send (async)
send @ jquery.js:10254
ajax @ jquery.js:9738
post @ storage.js:39
(anonymous) @ set-billing-address.js:51
placeOrder @ payment.js:234
(anonymous) @ knockout.js:3863
dispatch @ jquery.js:5226
elemData.handle @ jquery.js:4878
```

This fix adds a check if the variable is null even after hasOwnProperty is checked and sets as an empty string if needed.