### PR TITLE
v2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ matrix:
         - TEST_SUITE=integration
     - php: 7.1
       env:
-        - MAGENTO_VERSION=2.2.2
+        - MAGENTO_VERSION=2.2.4
         - TEST_SUITE=unit
     - php: 7.1
       env:
-        - MAGENTO_VERSION=2.2.2
+        - MAGENTO_VERSION=2.2.4
         - TEST_SUITE=integration
     - php: 7.0
       env:
@@ -47,11 +47,11 @@ matrix:
         - TEST_SUITE=integration
     - php: 7.0
       env:
-        - MAGENTO_VERSION=2.2.2
+        - MAGENTO_VERSION=2.2.4
         - TEST_SUITE=unit
     - php: 7.0
       env:
-        - MAGENTO_VERSION=2.2.2
+        - MAGENTO_VERSION=2.2.4
         - TEST_SUITE=integration
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ matrix:
   include:
     - php: 7.1
       env:
-        - MAGENTO_VERSION=2.3-develop
-        - TEST_SUITE=unit
-    - php: 7.1
-      env:
         - MAGENTO_VERSION=2.2-develop
         - TEST_SUITE=unit
     - php: 7.1
@@ -33,10 +29,6 @@ matrix:
       env:
         - MAGENTO_VERSION=2.2.4
         - TEST_SUITE=integration
-    - php: 7.0
-      env:
-        - MAGENTO_VERSION=2.3-develop
-        - TEST_SUITE=unit
     - php: 7.0
       env:
         - MAGENTO_VERSION=2.2-develop

--- a/Block/Info.php
+++ b/Block/Info.php
@@ -17,10 +17,46 @@
 namespace Pmclain\Stripe\Block;
 
 use Magento\Framework\Phrase;
+use Magento\Framework\View\Element\Template\Context;
 use Magento\Payment\Block\ConfigurableInfo;
+use Magento\Payment\Gateway\ConfigInterface;
+use Magento\Payment\Model\InfoInterface;
+use Magento\Vault\Api\PaymentTokenManagementInterface;
+use Magento\Framework\Serialize\SerializerInterface;
+use Pmclain\Stripe\Model\InstantPurchase\CreditCard\TokenFormatter;
 
 class Info extends ConfigurableInfo
 {
+    /**
+     * @var PaymentTokenManagementInterface
+     */
+    private $paymentTokenManagement;
+
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * Info constructor.
+     * @param Context $context
+     * @param ConfigInterface $config
+     * @param PaymentTokenManagementInterface $paymentTokenManagement
+     * @param SerializerInterface $serializer
+     * @param array $data
+     */
+    public function __construct(
+        Context $context,
+        ConfigInterface $config,
+        PaymentTokenManagementInterface $paymentTokenManagement,
+        SerializerInterface $serializer,
+        array $data = []
+    ) {
+        parent::__construct($context, $config, $data);
+        $this->paymentTokenManagement = $paymentTokenManagement;
+        $this->serializer = $serializer;
+    }
+
     /**
      * Returns label
      *
@@ -30,5 +66,87 @@ class Info extends ConfigurableInfo
     protected function getLabel($field)
     {
         return __($field);
+    }
+
+    /**
+     * @param null $transport
+     * @return \Magento\Framework\DataObject|null
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    protected function _prepareSpecificInformation($transport = null)
+    {
+        $transport = parent::_prepareSpecificInformation($transport);
+        $payment = $this->getInfo();
+
+        $this->setDataToTransfer(
+            $transport,
+            'Card Type',
+            $this->getCcType($payment)
+        );
+        $this->setDataToTransfer(
+            $transport,
+            'Card Last 4 Digits',
+            $this->getCcLast4($payment)
+        );
+
+        return $transport;
+    }
+
+    /**
+     * @param InfoInterface $payment
+     * @return string
+     */
+    private function getCcLast4(InfoInterface $payment)
+    {
+        if ($payment->getCcLast4()) {
+            return $payment->getCcLast4();
+        }
+
+        $token = $this->getPaymentToken($payment);
+        $details = $this->serializer->unserialize($token->getTokenDetails());
+
+        $last4 = '';
+        if (!empty($details['maskedCC'])) {
+            $last4 = $details['maskedCC'];
+        }
+
+        return $last4;
+    }
+
+    /**
+     * @param InfoInterface $payment
+     * @return string
+     */
+    private function getCcType(InfoInterface $payment)
+    {
+        if ($payment->getCcType()) {
+            return $payment->getCcType();
+        }
+
+        $token = $this->getPaymentToken($payment);
+        $details = $this->serializer->unserialize($token->getTokenDetails());
+
+        $type = '';
+        if (!empty($details['type'])) {
+            $type = $details['type'];
+        }
+
+        if (!empty(TokenFormatter::$baseCardTypes[$type])) {
+            $type = TokenFormatter::$baseCardTypes[$type];
+        }
+
+        return $type;
+    }
+
+    /**
+     * @param InfoInterface $payment
+     * @return \Magento\Vault\Api\Data\PaymentTokenInterface|null
+     */
+    private function getPaymentToken(InfoInterface $payment)
+    {
+        return $this->paymentTokenManagement->getByPublicHash(
+            $payment->getAdditionalInformation('public_hash'),
+            $payment->getAdditionalInformation('customer_id')
+        );
     }
 }

--- a/Model/InstantPurchase/CreditCard/TokenFormatter.php
+++ b/Model/InstantPurchase/CreditCard/TokenFormatter.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Pmclain_Stripe extension
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the OSL 3.0 License
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/osl-3.0.php
+ *
+ * @category  Pmclain
+ * @package   Pmclain_Stripe
+ * @copyright Copyright (c) 2017-2018
+ * @license   Open Software License (OSL 3.0)
+ */
+
+namespace Pmclain\Stripe\Model\InstantPurchase\CreditCard;
+
+use Magento\InstantPurchase\PaymentMethodIntegration\PaymentTokenFormatterInterface;
+use Magento\Vault\Api\Data\PaymentTokenInterface;
+
+class TokenFormatter implements PaymentTokenFormatterInterface
+{
+    /**
+     * Most used credit card types
+     * @var array
+     */
+    public static $baseCardTypes = [
+        'AE' => 'American Express',
+        'VI' => 'Visa',
+        'MC' => 'MasterCard',
+        'DI' => 'Discover',
+        'JBC' => 'JBC',
+        'CUP' => 'China Union Pay',
+        'MI' => 'Maestro',
+    ];
+
+    /**
+     * @inheritdoc
+     */
+    public function formatPaymentToken(PaymentTokenInterface $paymentToken): string
+    {
+        $details = json_decode($paymentToken->getTokenDetails() ?: '{}', true);
+        if (!isset($details['type'], $details['maskedCC'], $details['expirationDate'])) {
+            throw new \InvalidArgumentException('Invalid credit card token details.');
+        }
+
+        if (isset(self::$baseCardTypes[$details['type']])) {
+            $ccType = self::$baseCardTypes[$details['type']];
+        } else {
+            $ccType = $details['type'];
+        }
+
+        $formatted = sprintf(
+            '%s: %s, %s: %s (%s: %s)',
+            __('Credit Card'),
+            $ccType,
+            __('ending'),
+            $details['maskedCC'],
+            __('expires'),
+            $details['expirationDate']
+        );
+
+        return $formatted;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In your Magento 2 root directory run
 ## Magento Version Requirements
 | Release | Magento Version |
 | ------- | --------------- |
-| 1.x.x   | 2.2.x           | 
+| 2.x.x   | 2.2.x           |
 | 1.x.x   | 2.1.x           |
 | None    | 2.0.x           |
 

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
   "type": "magento2-module",
   "license": "OSL-3.0",
   "require": {
-    "php": "~7.0.0||~7.1.0",
-    "magento/framework": "~100.1.0||~101.0.0||~100.3.0-dev",
-    "stripe/stripe-php": "~6.3.0"
+    "php": "~7.0.0||~7.1.0||~7.2.0",
+    "magento/framework": "~101.0.0||~100.3.0-dev",
+    "stripe/stripe-php": "~6.7.0"
   },
   "autoload": {
     "files": [

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -58,6 +58,7 @@
         <active>1</active>
         <instant_purchase>
           <supported>1</supported>
+          <tokenFormat>Pmclain\Stripe\Model\InstantPurchase\CreditCard\TokenFormatter</tokenFormat>
         </instant_purchase>
       </pmclain_stripe_vault>
     </payment>


### PR DESCRIPTION
 * Require Magento 2.2.0 or greater
 * Add formatter for instant purchase card details
 * Add card type and last four digits to info block
 * Update to latest version of `stripe/stripe-php`