### PR TITLE
Fix for undefined variable 'stripeData' on authorize

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/pmclain_stripe.js
+++ b/view/frontend/web/js/view/payment/method-renderer/pmclain_stripe.js
@@ -308,8 +308,8 @@ define(
               ownerData.owner.address.state = billingAddress.regionCode;
           }
 
-          if (stripeData.address_state == null){
-            stripeData.address_state = '';
+          if (ownerData.owner.address.state == null){
+            ownerData.owner.address.state = '';
           }
 
           return ownerData;


### PR DESCRIPTION
On authorize, an error is thrown for 'stripeData' as it's not yet declared. Looking at the code, it seems the original fix was for ownerData, so I've replaced 'stripeData' in this instance with 'ownerData' which is what this function should be returning